### PR TITLE
Add README for OctoAcme Project Management Docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,66 @@
+# OctoAcme Project Management Documentation
+
+Welcome to the OctoAcme Project Management Documentation hub. This folder contains comprehensive guides for managing projects and delivering features at OctoAcme, from initiation through retrospectives.
+
+## Project Management Overview
+
+OctoAcme follows a structured, lifecycle-based approach to project management that prioritizes customer value, iterative delivery, and clear ownership. The framework consists of five core phases: **Initiation**, **Planning**, **Execution**, **Release**, and **Close & Retrospective**. During Initiation, teams validate business needs and create a lightweight Project One-pager that defines the problem statement, success metrics, stakeholders, and initial timeline. Once approved, the Planning phase breaks work into shippable increments, establishes a prioritized backlog with acceptance criteria, and identifies dependencies and risks. This disciplined approach ensures that projects move forward with clear alignment before development begins, reducing rework and scope creep.
+
+Execution is managed through a structured team rhythm featuring daily standups (15 minutes), weekly delivery syncs, and sprint-based iterations tracked on a project board. The organization emphasizes small pull requests (≤400 lines), automated testing in CI pipelines, and a peer-review requirement before code merges. Quality is ensured through unit tests, integration tests, end-to-end smoke tests, and security scanning. The team maintains a Risk Register updated weekly and follows a three-level escalation path (team triage → PM escalation → sponsor escalation) to address blockers efficiently. Release and Deployment operations are standardized with pre-release checklists, smoke test validation, and a documented rollback playbook to minimize production risk.
+
+OctoAcme defines clear roles and responsibilities across four key personas: Developers (who implement features and maintain code quality), Product Managers (who define what to build and prioritize based on customer value), Project Managers (who coordinate delivery, manage schedules and risks), and stakeholders (who provide inputs and approvals). This tri-party structure—with explicit ownership and collaboration points—reduces ambiguity and accelerates decision-making. Communication is formalized through weekly syncs between PM and Product Manager, twice-weekly team standups, monthly stakeholder updates, and ad-hoc escalations, ensuring transparency and alignment across the organization.
+
+Finally, OctoAcme embeds continuous improvement into its culture through structured retrospectives held after each sprint, release, or milestone. Teams discuss what went well, identify improvements, and assign specific action items with owners and due dates. These improvements are tracked in the project backlog and reviewed during weekly syncs, creating a feedback loop that strengthens processes over time. By combining disciplined planning, clear roles, consistent communication cadences, and a commitment to learning, OctoAcme enables teams to deliver high-quality software reliably while maintaining psychological safety and organizational alignment.
+
+---
+
+## Process Documentation Index
+
+### 📋 Core Framework
+- **[OctoAcme Project Management Overview](./octoacme-project-management-overview.md)** — High-level introduction to OctoAcme's approach, core principles, key roles, and artifacts.
+
+### 🚀 Project Lifecycle
+
+- **[Project Initiation Guide](./octoacme-project-initiation.md)** — Steps to validate and authorize work, align stakeholders, and create a lightweight Project One-pager.
+
+- **[Project Planning](./octoacme-project-planning.md)** — Turn an approved initiative into an actionable plan and backlog for delivery; includes backlog templates and Definition of Done.
+
+- **[Execution & Tracking](./octoacme-execution-and-tracking.md)** — Manage day-to-day execution, team rhythm, pull request workflows, quality assurance, and blocker escalation.
+
+- **[Release & Deployment Guide](./octoacme-release-and-deployment.md)** — Standardize release processes, pre-release requirements, deployment checklists, and rollback procedures.
+
+- **[Retrospective & Continuous Improvement](./octoacme-retrospective-and-continuous-improvement.md)** — Capture learnings and convert them into actionable improvements; structure and tracking of action items.
+
+### 🎯 Cross-Cutting Concerns
+
+- **[Risk Management & Communication](./octoacme-risks-and-communication.md)** — Identify, assess, and mitigate risks; manage stakeholder communication and escalation paths.
+
+- **[Roles & Personas](./octoacme-roles-and-personas.md)** — Define responsibilities and typical communication patterns for Developers, Product Managers, Project Managers, and stakeholders.
+
+---
+
+## Quick Start
+
+**New to OctoAcme projects?** Start here:
+
+1. Read the [Project Management Overview](./octoacme-project-management-overview.md) to understand our principles and lifecycle.
+2. Review the [Roles & Personas](./octoacme-roles-and-personas.md) to understand who does what.
+3. Follow the guides in order as your project progresses: **Initiation → Planning → Execution → Release → Retrospective**.
+
+**Looking for a specific process?** Use the index above to jump to the relevant document.
+
+---
+
+## Key Principles
+
+- **Customer-first**: Prioritize customer value and usability.
+- **Iterative delivery**: Deliver small, testable increments.
+- **Clear ownership**: Each project has a named Project Manager and Product Lead.
+- **Data-informed decisions**: Measure impact and iterate based on evidence.
+- **Psychological safety**: Encourage feedback and learning.
+
+---
+
+## Contact & Questions
+
+For questions about OctoAcme's project management processes, please reach out to your Project Manager or Product Lead, or open an issue in the project repository.


### PR DESCRIPTION
Added [README.md](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Includes OctoAcme project management documentation overview
No code changes, docs-only update